### PR TITLE
PR: added KR support & submodule inclusion corrected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 # Project specific files
 *.log
 *.pem
-data/
 .version
 
 # Binaries for programs and plugins

--- a/discord/rpc.go
+++ b/discord/rpc.go
@@ -24,6 +24,7 @@ const (
 	largeImageID     = "arknights"
 	largeImageText   = "Arknights"
 	largeImageTextJP = "アークナイツ"
+	largeImageTextKR = "명일방주"
 	idleText         = "Idling"
 	practiceText     = "Practicing "
 	autoplayText     = "Autoing "
@@ -94,6 +95,8 @@ func (mod *modState) syncData() {
 	mod.activity.Details = fmt.Sprintf("[%s] %s#%s", mod.Region, s.NickName, s.NickNumber)
 	if mod.Region == "JP" {
 		mod.activity.LargeText = largeImageTextJP
+	} else if mod.Region == "KR" {
+		mod.activity.LargeText = largeImageTextKR
 	}
 	mod.updateActivity()
 }


### PR DESCRIPTION
Hi again, here is KR addition for discord rpc module!
I also added "data" folder as a git submodule, by deleting `data/` from `.gitignore`.

The only thing remained for this Rhine module to really support KR server is to update `go.mod` file.

How about this PR?

Thanks!